### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-5.2 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 6.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-09-04)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*rnames):
         return f.read()
 
 
-version = '5.2.dev0'
+version = '6.0.dev0'
 
 setup(name='zope.app.container',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -58,9 +57,6 @@ setup(name='zope.app.container',
       ],
       url='http://github.com/zopefoundation/zope.app.container',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       extras_require={
           'test': [
@@ -90,7 +86,7 @@ setup(name='zope.app.container',
               'zope.site',
               'zope.testbrowser>5',
               'zope.testing',
-              'zope.testrunner',
+              'zope.testrunner >= 6.4',
           ]},
       install_requires=[
           'setuptools',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,2 +1,0 @@
-# this is a namespace package
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,2 +1,0 @@
-# this is a namespace package
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
